### PR TITLE
Travis: Also install YAEP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ script:
   - cd src
   - make
   - make test
+  - sudo env "PATH=$PATH" make install

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -61,7 +61,7 @@
 
 SHELL=/bin/sh
 
-# The subdirectory used for copying sources and creation of 
+# The subdirectory used for copying sources and creation of
 # compressed distribution tar file.
 distdir = yaep-0.997
 
@@ -159,7 +159,7 @@ doc_files = yaep.txt yaep.info* yaep.html yaep-*.html\
 
 # Files which are not in distribution
 additional_rcs_files = yaep.sgml.in yaep_part.sgml.in\
-                       yaep++.sgml.in yaep_part++.sgml.in 
+                       yaep++.sgml.in yaep_part++.sgml.in
 
 # All C object files
 Cobjects = $(Cdir)/allocate.o  $(Cdir)/vlobject.o  $(Cdir)/objstack.o\
@@ -331,7 +331,7 @@ yaep.sgml: $(srcdir)/yaep.sgml.in $(srcdir)/yaep_part.sgml.in
 $(srcdir)/yaep.txt: yaep.sgml
 	linuxdoc -B txt --papersize=letter -f yaep.sgml
 	mv yaep.txt $(srcdir)
-	
+
 $(srcdir)/yaep.html: yaep.sgml
 	linuxdoc -B html --papersize=letter yaep.sgml
 	if test -f yaep-1.html;then\
@@ -340,7 +340,7 @@ $(srcdir)/yaep.html: yaep.sgml
 	  done;\
         fi
 	mv yaep.html $(srcdir)/yaep.html
-	
+
 $(srcdir)/yaep.info: yaep.sgml
 	linuxdoc -B info --papersize=letter yaep.sgml
 	if test -f yaep.info;then\
@@ -348,7 +348,7 @@ $(srcdir)/yaep.info: yaep.sgml
    	    mv $$i $(srcdir)/$$i;\
 	  done;\
         fi
-	
+
 $(srcdir)/yaep.dvi: yaep.sgml
 	linuxdoc -B latex --papersize=letter yaep.sgml
 	if test ! -f yaep.dvi\
@@ -381,7 +381,7 @@ $(srcdir)/yaep++.html: yaep++.sgml
 	  done;\
         fi
 	mv yaep++.html $(srcdir)/yaep++.html
-	
+
 $(srcdir)/yaep++.info: yaep++.sgml
 	linuxdoc -B info --papersize=letter yaep++.sgml
 	if test -f yaep++.info;then\
@@ -389,7 +389,7 @@ $(srcdir)/yaep++.info: yaep++.sgml
    	    mv $$i $(srcdir)/$$i;\
 	  done;\
         fi
-	
+
 $(srcdir)/yaep++.dvi: yaep++.sgml
 	linuxdoc -B latex --papersize=letter yaep++.sgml
 	if test ! -f yaep++.dvi\
@@ -430,7 +430,7 @@ depend : sgramm.c $(Cdir) $(Cxxdir)
                 | $(SED) 's%\$$(top_srcdir)/src/sgramm\.c%sgramm.c%g' \
                          >>Makefile.tmp;\
 	done
-	
+
 	@echo ++++ Adding Makefile dependencies for C++ ++++
 	for i in allocate.cpp vlobject.cpp objstack.cpp hashtab.cpp ticker.cpp yaep.cpp;\
 	do\


### PR DESCRIPTION
While the changes in commit 7d1bb5c might be controversial, it makes sense in my opinion to also offer support for an allocation facility “out of the box”. At least as [user of this library](https://github.com/ElektraInitiative/libelektra/pull/2251), I am currently not really interested on how it allocates memory for the parse tree. This might change over time, but I assume most people just want an nice default allocation function, which `objstack.h` seems to offer.

This pull request also reverts commit 1a5f6cb. While I also noticed that the library seems to leak memory, I still think the unit tests should pass, after someone applies a fix for the problematic code.

If I should change anything in this PR, please just comment below. Thank you.